### PR TITLE
feat(cmdlet): ✨ Enhance `ShowTextMateCmdlet` for improved input handling

### DIFF
--- a/src/Helpers/Completers.cs
+++ b/src/Helpers/Completers.cs
@@ -1,17 +1,95 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+using System.Text.RegularExpressions;
 
 namespace PwshSpectreConsole.TextMate;
-public class TextMateLanguages : IValidateSetValuesGenerator
+
+public sealed class LanguageCompleter : IArgumentCompleter
 {
-    public string[] GetValidValues()
+    /// <summary>
+    /// Offers completion for both TextMate language ids and file extensions.
+    /// Examples: "powershell", "csharp", ".md", "md", ".ps1", "ps1".
+    /// </summary>
+    public IEnumerable<CompletionResult> CompleteArgument(
+        string commandName,
+        string parameterName,
+        string wordToComplete,
+        CommandAst commandAst,
+        IDictionary fakeBoundParameters)
     {
-        return TextMateHelper.Languages;
-    }
-    public static bool IsSupportedLanguage(string language)
-    {
-        return TextMateHelper.Languages.Contains(language);
+        string input = wordToComplete ?? string.Empty;
+        bool wantsExtensionsOnly = input.Length > 0 && input[0] == '.';
+
+        // Prefer wildcard matching semantics; fall back to prefix/contains when empty
+        WildcardPattern? pattern = null;
+        if (!string.IsNullOrEmpty(input))
+        {
+            // Add trailing * if not already present to make incremental typing friendly
+            string normalized = input[^1] == '*' ? input : input + "*";
+            pattern = new WildcardPattern(normalized, WildcardOptions.IgnoreCase);
+        }
+
+        bool Match(string token)
+        {
+            if (pattern is null) return true; // no filter
+            if (pattern.IsMatch(token)) return true;
+            // Also test without a leading dot to match bare extensions like "ps1" against ".ps1"
+            return token.StartsWith('.') && pattern.IsMatch(token[1..]);
+        }
+
+        // Build suggestions
+        var results = new List<CompletionResult>();
+
+        if (!wantsExtensionsOnly)
+        {
+            // Languages first
+            foreach (string lang in TextMateHelper.Languages ?? Array.Empty<string>())
+            {
+                if (!Match(lang)) continue;
+                results.Add(new CompletionResult(
+                    completionText: lang,
+                    listItemText: lang,
+                    resultType: CompletionResultType.ParameterValue,
+                    toolTip: "TextMate language"));
+            }
+        }
+
+        // Extensions (always include if requested or no leading '.')
+        foreach (string ext in TextMateHelper.Extensions ?? Array.Empty<string>())
+        {
+            if (!Match(ext)) continue;
+            string completion = ext; // keep dot in completion
+            string display = ext;
+            results.Add(new CompletionResult(
+                completionText: completion,
+                listItemText: display,
+                resultType: CompletionResultType.ParameterValue,
+                toolTip: "File extension"));
+        }
+
+        // De-duplicate (in case of overlaps) and sort: languages first, then extensions, each alphabetically
+        return results
+            .GroupBy(r => r.CompletionText, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .OrderByDescending(r => r.ToolTip.Equals("TextMate language", StringComparison.Ordinal))
+            .ThenBy(r => r.CompletionText, StringComparer.OrdinalIgnoreCase);
     }
 }
+public class TextMateLanguages : IValidateSetValuesGenerator
+    {
+        public string[] GetValidValues()
+        {
+            return TextMateHelper.Languages;
+        }
+        public static bool IsSupportedLanguage(string language)
+        {
+            return TextMateHelper.Languages.Contains(language);
+        }
+    }
 public class TextMateExtensions : IValidateSetValuesGenerator
 {
     public string[] GetValidValues()

--- a/src/Helpers/TextMateResolver.cs
+++ b/src/Helpers/TextMateResolver.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace PwshSpectreConsole.TextMate;
+
+/// <summary>
+/// Resolves a user-provided token into either a TextMate language id or a file extension.
+/// </summary>
+internal static class TextMateResolver
+{
+    /// <summary>
+    /// Resolve a grammar token that may be a language id or a file extension.
+    /// Heuristics:
+    /// - If starts with '.', treat as extension
+    /// - If known TextMate language id, treat as language
+    /// - Otherwise treat as extension (allow values like 'ps1', 'md')
+    /// </summary>
+    public static (string token, bool asExtension) ResolveToken(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ("powershell", false);
+        }
+
+        string v = value.Trim();
+        if (v.StartsWith('.'))
+        {
+            return (v, true);
+        }
+
+        if (TextMateLanguages.IsSupportedLanguage(v))
+        {
+            return (v, false);
+        }
+
+        // Treat anything else as an extension; prefix a dot if missing
+        return (v.StartsWith('.') ? v : "." + v, true);
+    }
+}


### PR DESCRIPTION
* Changed `InputObject` type from `object?` to `string?` for better type safety.
* Introduced `_sourceExtensionHint` to capture extension hints from pipeline objects.
* Updated `ProcessRecord` to handle both string and path inputs more effectively.
* Added logic to resolve language tokens and file extensions in `ProcessStringInput` and `ProcessPathInput`.
* Implemented a new `TextMateResolver` class to encapsulate token resolution logic.